### PR TITLE
Manage dependencies using buildSrc

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -9,6 +9,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/features" />
             <option value="$PROJECT_DIR$/features/account" />
             <option value="$PROJECT_DIR$/features/transactions" />

--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinScriptingSettings">
+    <option name="isAutoReloadEnabled" value="true" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
+apply from: 'https://raw.githubusercontent.com/JakeWharton/SdkSearch/master/gradle/projectDependencyGraph.gradle'
 
 android {
     compileSdkVersion Versions.compileSdkVersion

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,11 +13,11 @@ android {
         experimental = true
     }
     defaultConfig {
-        applicationId "me.manulorenzo.moneytransactions"
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        applicationId ApplicationId.id
+        minSdkVersion Versions.minSdkVersion
+        targetSdkVersion Versions.targetSdkVersion
+        versionCode Releases.versionCode
+        versionName Releases.versionName
         testInstrumentationRunner "me.manulorenzo.moneytransactions.TestAppRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,12 +33,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation project(":libraries:data-account")
-    implementation project(':libraries:data-transactions')
-    implementation project(":libraries:repository")
-    implementation project(":libraries:presentation")
-    implementation project(":features:account")
-    implementation project(":features:transactions")
+    implementation project(Modules.data_account)
+    implementation project(Modules.data_transactions)
+    implementation project(Modules.repository)
+    implementation project(Modules.presentation)
+    implementation project(Modules.features_account)
+    implementation project(Modules.features_transactions)
 
     implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
     implementation "org.koin:koin-android:2.0.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion Versions.compileSdkVersion
+    buildToolsVersion Versions.buildToolsVersion
     testOptions {
         animationsDisabled = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,21 +40,21 @@ dependencies {
     implementation project(Modules.features_account)
     implementation project(Modules.features_transactions)
 
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
-    implementation "org.koin:koin-android:2.0.1"
-    implementation "org.koin:koin-androidx-viewmodel:2.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.core:core-ktx:1.1.0"
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    testImplementation "org.koin:koin-test:2.0.1"
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.robolectric:robolectric:4.3"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "android.arch.core:core-testing:1.1.1"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
+    implementation Libraries.threeTenAbpJakeWharton
+    implementation Libraries.koinAndroid
+    implementation Libraries.koinViewModel
+    implementation Libraries.kotlin
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    implementation SupportLibraries.constraintLayout
+    implementation SupportLibraries.cardview
+    implementation SupportLibraries.legacy
+    testImplementation TestLibraries.koinTest
+    testImplementation TestLibraries.junit
+    testImplementation TestLibraries.robolectric
+    testImplementation TestLibraries.mockitoKotlin
+    testImplementation TestLibraries.lifecycleTesting
+    testImplementation TestLibraries.coroutinesTest
 
     androidTestImplementation "androidx.test:runner:1.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,19 +56,19 @@ dependencies {
     testImplementation TestLibraries.lifecycleTesting
     testImplementation TestLibraries.coroutinesTest
 
-    androidTestImplementation "androidx.test:runner:1.2.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
-    androidTestImplementation('org.threeten:threetenbp:1.4.0') {
+    androidTestImplementation TestLibraries.testRunner
+    androidTestImplementation TestLibraries.espressoCore
+    androidTestImplementation(TestLibraries.threeTenAbp) {
         exclude group: 'com.jakewharton.threetenabp', module: 'threetenabp'
     }
     // debugImplementation because LeakCanary should only run in debug builds.
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.0-beta-3"
-    debugImplementation('androidx.fragment:fragment-testing:1.1.0') {
+    androidTestImplementation TestLibraries.espressoCore
+    androidTestImplementation TestLibraries.espressoContrib
+    androidTestImplementation TestLibraries.testRunner
+    androidTestImplementation TestLibraries.extRules
+    androidTestImplementation TestLibraries.extJunit
+    debugImplementation Libraries.leakCanaryAndroid
+    debugImplementation(TestLibraries.fragmentTesting) {
         exclude group: 'androidx.test', module: 'core'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply plugin: Plugins.gradleVersions
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath Libraries.gradle
+        classpath Libraries.gradleKotlin
+        classpath Libraries.gradleVersions
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    `kotlin-dsl`
+}
+repositories {
+    jcenter()
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,8 +34,6 @@ object Versions {
     const val targetSdkVersion = 29
     const val compileSdkVersion = 29
     const val buildToolsVersion = "29.0.2"
-    const val support_lib = "27.0.2"
-    const val rxjava = "2.1.9"
     const val gradle = "3.4.2"
     const val threeTenAbpJakeWharton = "1.2.1"
     const val appcompat = "1.0.2"
@@ -51,6 +49,7 @@ object Versions {
     const val junit = "4.12"
     const val mockitoKotlin = "2.1.0"
     const val mockitoInline = "3.0.0"
+    const val coroutinesCore = "1.3.2"
 }
 
 object Plugins {
@@ -64,8 +63,9 @@ object Libraries {
     const val moshiKotlin = "com.squareup.moshi:moshi-kotlin:${Versions.moshi}"
     const val moshiAdapters = "com.squareup.moshi:moshi-adapters:${Versions.moshi}"
     const val moshiCodegen = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}"
-    val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:${Versions.lifecycle}"
-    val lifecycleCompiler = "androidx.lifecycle:lifecycle-compiler:${Versions.lifecycle}"
+    const val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:${Versions.lifecycle}"
+    const val lifecycleViewModel =
+        "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.lifecycleViewModel}"
     const val leakCanaryAndroid =
         "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
     const val koinAndroid = "org.koin:koin-android:${Versions.koin}"
@@ -81,9 +81,8 @@ object Libraries {
 
 object SupportLibraries {
     const val appcompat = "androidx.appcompat:appcompat:${Versions.appcompat}"
-    val design = "com.google.android.material:material:${Versions.design}"
     const val cardview = "androidx.cardview:cardview:${Versions.cardview}"
-    val recyclerview = "androidx.recyclerview:recyclerview:${Versions.recyclerview}"
+    const val recyclerview = "androidx.recyclerview:recyclerview:${Versions.recyclerview}"
     const val constraintLayout =
         "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
     const val legacy = "androidx.legacy:legacy-support-v4:${Versions.legacy}"
@@ -92,7 +91,7 @@ object SupportLibraries {
 object TestLibraries {
     const val junit = "junit:junit:${Versions.junit}"
     const val mockitoKotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}"
-    val mockitoInline = "org.mockito:mockito-inline:${Versions.mockitoInline}"
+    const val mockitoInline = "org.mockito:mockito-inline:${Versions.mockitoInline}"
     const val lifecycleTesting = "androidx.arch.core:core-testing:${Versions.lifecycle}"
     const val koinTest = "org.koin:koin-test:${Versions.koin}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -18,6 +18,8 @@ object Releases {
 }
 
 object Versions {
+    const val gradleVersions = "0.27.0"
+    const val lifecycleViewModel = "2.1.0"
     const val legacy = "1.0.0"
     const val fragmentTesting = "1.1.0"
     const val extJunit = "1.1.1"
@@ -41,9 +43,7 @@ object Versions {
     const val cardview = "1.0.0"
     const val recyclerview = "1.0.0"
     const val ktx = "1.0.0-alpha1"
-    const val kotlin = "1.3.41"
-    const val retrofit = "2.6.0"
-    const val loggingInterceptor = "4.0.0"
+    const val kotlin = "1.3.50"
     const val moshi = "1.8.0"
     const val lifecycle = "2.0.0"
     const val leakCanary = "2.0-beta-3"
@@ -53,8 +53,13 @@ object Versions {
     const val mockitoInline = "3.0.0"
 }
 
+object Plugins {
+    const val gradleVersions = "com.github.ben-manes.versions"
+}
+
 object Libraries {
     const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+    const val gradleKotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val ktx = "androidx.core:core-ktx:${Versions.ktx}"
     const val moshiKotlin = "com.squareup.moshi:moshi-kotlin:${Versions.moshi}"
     const val moshiAdapters = "com.squareup.moshi:moshi-adapters:${Versions.moshi}"
@@ -67,6 +72,11 @@ object Libraries {
     const val koinViewModel = "org.koin:koin-androidx-viewmodel:${Versions.koin}"
     const val threeTenAbpJakeWharton =
         "com.jakewharton.threetenabp:threetenabp:${Versions.threeTenAbpJakeWharton}"
+    const val coroutinesCore =
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutinesCore}"
+    const val gradle = "com.android.tools.build:gradle:${Versions.gradle}"
+    const val gradleVersions =
+        "com.github.ben-manes:gradle-versions-plugin:${Versions.gradleVersions}"
 }
 
 object SupportLibraries {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,0 +1,98 @@
+object ApplicationId {
+    const val id = "me.manulorenzo.moneytransactions"
+}
+
+object Modules {
+    const val app = ":app"
+    const val data_account = ":libraries:data-account"
+    const val data_transactions = ":libraries:data-transactions"
+    const val repository = ":libraries:repository"
+    const val features_account = ":features:account"
+    const val features_transactions = ":features:transactions"
+    const val presentation = ":libraries:presentation"
+}
+
+object Releases {
+    const val versionCode = 1
+    const val versionName = "1.0"
+}
+
+object Versions {
+    const val legacy = "1.0.0"
+    const val fragmentTesting = "1.1.0"
+    const val extJunit = "1.1.1"
+    const val extRules = "1.2.0"
+    const val threeTenAbp = "1.4.0"
+    const val espresso = "3.2.0"
+    const val testRunner = "1.2.0"
+    const val coroutinesTest = "1.3.2"
+    const val robolectric = "4.3.1"
+    const val constraintLayout = "1.1.3"
+    const val minSdkVersion = 21
+    const val targetSdkVersion = 29
+    const val compileSdkVersion = 29
+    const val buildToolsVersion = "29.0.2"
+    const val support_lib = "27.0.2"
+    const val rxjava = "2.1.9"
+    const val gradle = "3.4.2"
+    const val threeTenAbpJakeWharton = "1.2.1"
+    const val appcompat = "1.0.2"
+    const val design = "1.0.0"
+    const val cardview = "1.0.0"
+    const val recyclerview = "1.0.0"
+    const val ktx = "1.0.0-alpha1"
+    const val kotlin = "1.3.41"
+    const val retrofit = "2.6.0"
+    const val loggingInterceptor = "4.0.0"
+    const val moshi = "1.8.0"
+    const val lifecycle = "2.0.0"
+    const val leakCanary = "2.0-beta-3"
+    const val koin = "2.0.0-beta-1"
+    const val junit = "4.12"
+    const val mockitoKotlin = "2.1.0"
+    const val mockitoInline = "3.0.0"
+}
+
+object Libraries {
+    const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+    const val ktx = "androidx.core:core-ktx:${Versions.ktx}"
+    const val moshiKotlin = "com.squareup.moshi:moshi-kotlin:${Versions.moshi}"
+    const val moshiAdapters = "com.squareup.moshi:moshi-adapters:${Versions.moshi}"
+    const val moshiCodegen = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}"
+    val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:${Versions.lifecycle}"
+    val lifecycleCompiler = "androidx.lifecycle:lifecycle-compiler:${Versions.lifecycle}"
+    const val leakCanaryAndroid =
+        "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
+    const val koinAndroid = "org.koin:koin-android:${Versions.koin}"
+    const val koinViewModel = "org.koin:koin-androidx-viewmodel:${Versions.koin}"
+    const val threeTenAbpJakeWharton =
+        "com.jakewharton.threetenabp:threetenabp:${Versions.threeTenAbpJakeWharton}"
+}
+
+object SupportLibraries {
+    const val appcompat = "androidx.appcompat:appcompat:${Versions.appcompat}"
+    val design = "com.google.android.material:material:${Versions.design}"
+    const val cardview = "androidx.cardview:cardview:${Versions.cardview}"
+    val recyclerview = "androidx.recyclerview:recyclerview:${Versions.recyclerview}"
+    const val constraintLayout =
+        "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
+    const val legacy = "androidx.legacy:legacy-support-v4:${Versions.legacy}"
+}
+
+object TestLibraries {
+    const val junit = "junit:junit:${Versions.junit}"
+    const val mockitoKotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}"
+    val mockitoInline = "org.mockito:mockito-inline:${Versions.mockitoInline}"
+    const val lifecycleTesting = "androidx.arch.core:core-testing:${Versions.lifecycle}"
+    const val koinTest = "org.koin:koin-test:${Versions.koin}"
+    const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
+    const val coroutinesTest =
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutinesTest}"
+    const val testRunner = "androidx.test:runner:${Versions.testRunner}"
+    const val espressoCore = "androidx.test.espresso:espresso-core:${Versions.espresso}"
+    const val espressoContrib = "androidx.test.espresso:espresso-contrib:${Versions.espresso}"
+    const val threeTenAbp = "org.threeten:threetenbp:${Versions.threeTenAbp}"
+    const val extRules = "androidx.test:rules:${Versions.extRules}"
+    const val extJunit = "androidx.test.ext:junit:${Versions.extJunit}"
+    const val fragmentTesting = "androidx.fragment:fragment-testing:${Versions.fragmentTesting}"
+}

--- a/features/account/build.gradle
+++ b/features/account/build.gradle
@@ -29,39 +29,42 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':libraries:presentation')
-    testImplementation project(':libraries:presentation')
-    androidTestImplementation project(':libraries:presentation')
-    implementation project(':libraries:data-account')
-    testImplementation project(':libraries:data-account')
-    implementation project(':libraries:data-transactions')
-    testImplementation project(':libraries:data-transactions')
-    implementation project(':libraries:repository')
+    implementation project(Modules.presentation)
+    androidTestImplementation project(Modules.presentation)
+    testImplementation project(Modules.presentation)
 
-    implementation "org.koin:koin-android:2.0.1"
-    implementation "org.koin:koin-androidx-viewmodel:2.0.1"
-    testImplementation "org.koin:koin-test:2.0.1"
-    kaptTest "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
-    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation project(Modules.data_account)
+    testImplementation project(Modules.data_account)
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation "android.arch.core:core-testing:1.1.1"
-    testImplementation "com.squareup.moshi:moshi-kotlin:1.8.0"
-    testImplementation "com.squareup.moshi:moshi-adapters:1.8.0"
+    implementation project(Modules.data_transactions)
+    testImplementation project(Modules.data_transactions)
 
-    androidTestImplementation 'org.mockito:mockito-android:3.0.0'
-    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation "android.arch.core:core-testing:1.1.1"
-    androidTestImplementation "junit:junit:4.12"
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    implementation project(Modules.repository)
+
+    implementation Libraries.koinAndroid
+    implementation Libraries.koinViewModel
+    testImplementation TestLibraries.koinTest
+    kaptTest Libraries.moshiCodegen
+    implementation Libraries.threeTenAbpJakeWharton
+    implementation SupportLibraries.recyclerview
+    implementation Libraries.lifecycleExtensions
+    implementation Libraries.lifecycleViewModel
+    implementation Libraries.kotlin
+    implementation Libraries.coroutinesCore
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+
+    testImplementation TestLibraries.junit
+    testImplementation TestLibraries.lifecycleTesting
+    testImplementation Libraries.moshiKotlin
+    testImplementation Libraries.moshiAdapters
+
+    androidTestImplementation TestLibraries.mockitoInline
+    androidTestImplementation TestLibraries.mockitoKotlin
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
+    androidTestImplementation TestLibraries.lifecycleTesting
+    androidTestImplementation TestLibraries.junit
+    androidTestImplementation TestLibraries.coroutinesTest
+    androidTestImplementation TestLibraries.extRules
 }

--- a/features/transactions/build.gradle
+++ b/features/transactions/build.gradle
@@ -27,11 +27,11 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libraries:data-transactions')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation Libraries.kotlin
+    implementation Libraries.threeTenAbpJakeWharton
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    testImplementation TestLibraries.junit
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
 }

--- a/features/transactions/build.gradle
+++ b/features/transactions/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':libraries:data-transactions')
+    implementation project(Modules.data_transactions)
     implementation Libraries.kotlin
     implementation Libraries.threeTenAbpJakeWharton
     implementation SupportLibraries.appcompat

--- a/libraries/data-account/build.gradle
+++ b/libraries/data-account/build.gradle
@@ -29,15 +29,15 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':libraries:data-transactions')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation "com.squareup.moshi:moshi-kotlin:1.8.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation project(Modules.data_transactions)
+    implementation Libraries.kotlin
+    implementation Libraries.coroutinesCore
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    implementation Libraries.moshiKotlin
+    implementation Libraries.moshiAdapters
+    kapt Libraries.moshiCodegen
+    testImplementation TestLibraries.junit
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
 }

--- a/libraries/data-transactions/build.gradle
+++ b/libraries/data-transactions/build.gradle
@@ -30,14 +30,14 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation "com.squareup.moshi:moshi-kotlin:1.8.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation Libraries.kotlin
+    implementation Libraries.threeTenAbpJakeWharton
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    implementation Libraries.moshiKotlin
+    implementation Libraries.moshiAdapters
+    kapt Libraries.moshiCodegen
+    testImplementation TestLibraries.junit
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
 }

--- a/libraries/presentation/build.gradle
+++ b/libraries/presentation/build.gradle
@@ -36,20 +36,20 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(":libraries:data-account")
-    implementation project(':libraries:data-transactions')
-    implementation "com.squareup.moshi:moshi-kotlin:1.8.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    implementation "org.koin:koin-android:2.0.1"
-    implementation "org.koin:koin-androidx-viewmodel:2.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation project(Modules.data_account)
+    implementation project(Modules.data_transactions)
+    implementation Libraries.moshiKotlin
+    implementation Libraries.moshiAdapters
+    kapt Libraries.moshiCodegen
+    implementation Libraries.koinAndroid
+    implementation Libraries.koinViewModel
+    implementation Libraries.kotlin
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    implementation Libraries.coroutinesCore
+    implementation Libraries.threeTenAbpJakeWharton
+    testImplementation TestLibraries.junit
+    testImplementation TestLibraries.coroutinesTest
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
 }

--- a/libraries/repository/build.gradle
+++ b/libraries/repository/build.gradle
@@ -29,22 +29,22 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(":libraries:data-account")
-    implementation project(':libraries:data-transactions')
+    implementation project(Modules.data_account)
+    implementation project(Modules.data_transactions)
 
-    implementation "org.koin:koin-android:2.0.1"
-    implementation "org.koin:koin-androidx-viewmodel:2.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation "com.squareup.moshi:moshi-kotlin:1.8.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    testImplementation "org.koin:koin-android:2.0.1"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.koin:koin-test:2.0.1"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation Libraries.koinAndroid
+    implementation Libraries.koinViewModel
+    implementation Libraries.kotlin
+    implementation SupportLibraries.appcompat
+    implementation Libraries.ktx
+    implementation Libraries.moshiKotlin
+    implementation Libraries.moshiAdapters
+    kapt Libraries.moshiCodegen
+    testImplementation Libraries.koinAndroid
+    testImplementation TestLibraries.junit
+    testImplementation TestLibraries.koinTest
+    testImplementation TestLibraries.mockitoKotlin
+    testImplementation TestLibraries.coroutinesTest
+    androidTestImplementation TestLibraries.extJunit
+    androidTestImplementation TestLibraries.espressoCore
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':app', ':libraries:data-account', ':libraries:data-transactions', ':libraries:repository', ':features:account', ':features:transactions', ':libraries:presentation'
-rootProject.name='MoneyTransactions'
+include Modules.app, Modules.data_account, Modules.data_transactions, Modules.repository, Modules.features_account, Modules.features_transactions, Modules.presentation
+rootProject.name = 'MoneyTransactions'


### PR DESCRIPTION
- [X] Create `buildSrc` folder for managing dependencies using Kotlin
- [X] Modify `gradle` files of the submodules to make use of the `buildSrc/Dependencies.kt` file